### PR TITLE
Allow parentheses and equals signs in test names

### DIFF
--- a/bin/genhtml
+++ b/bin/genhtml
@@ -1526,7 +1526,7 @@ sub read_info_file($)
 			{
 				# Test name information found
 				$testname = defined($1) ? $1 : "";
-				if ($testname =~ s/[^a-zA-Z0-9_.@-]/_/g)
+				if ($testname =~ s/[^a-zA-Z0-9_.@=()-]/_/g)
 				{
 					$changed_testname = 1;
 				}
@@ -2568,7 +2568,7 @@ sub read_testfile($)
 		{
 			# Store name for later use
 			$test_name = $1;
-			if ($test_name =~ s/[^a-zA-Z0-9_.@-]/_/g)
+			if ($test_name =~ s/[^a-zA-Z0-9_.@=()-]/_/g)
 			{
 				$changed_testname = 1;
 			}

--- a/bin/geninfo
+++ b/bin/geninfo
@@ -540,7 +540,7 @@ parse_compat_modes($opt_compat);
 parse_ignore_errors(@ignore_errors);
 
 # Make sure test names only contain valid characters
-if ($test_name =~ s/[^a-zA-Z0-9_.@-]/_/g)
+if ($test_name =~ s/[^a-zA-Z0-9_.@=()-]/_/g)
 {
 	warn("WARNING: invalid characters removed from testname!\n");
 }
@@ -549,7 +549,7 @@ if ($test_name =~ s/[^a-zA-Z0-9_.@-]/_/g)
 if ($adjust_testname)
 {
 	$test_name .= "__".`uname -a`;
-	$test_name =~ s/[^a-zA-Z0-9_.@-]/_/g;
+	$test_name =~ s/[^a-zA-Z0-9_.@=()-]/_/g;
 }
 
 # Make sure base_directory contains an absolute path specification

--- a/bin/lcov
+++ b/bin/lcov
@@ -1655,7 +1655,7 @@ sub read_info_file($)
 			{
 				# Test name information found
 				$testname = defined($1) ? $1 : "";
-				if ($testname =~ s/[^a-zA-Z0-9_.@-]/_/g)
+				if ($testname =~ s/[^a-zA-Z0-9_.@=()-]/_/g)
 				{
 					$changed_testname = 1;
 				}


### PR DESCRIPTION
Update sanitization regex to keep =, (, ) characters in test names